### PR TITLE
Rename dsd app from `simple_deploy` to `django_simple_deploy`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ Changelog: dsd-platformsh
 0.9 - Simplified usage from core
 ---
 
+### 0.9.3 (skipping 0.9.2 to match pre-1.0 version of django-simple-deploy)
+
+#### External changes
+
+- Updated to match core app name change from `simple_deploy` to `django-simple-deploy`.
+
+#### Internal changes
+
+- Minor naming changes to make project consistent with current names in core.
+
 ### 0.9.1
 
 #### External changes

--- a/dsd_platformsh/__init__.py
+++ b/dsd_platformsh/__init__.py
@@ -1,2 +1,2 @@
-from .deploy import simple_deploy_get_plugin_config
-from .deploy import simple_deploy_deploy
+from .deploy import dsd_get_plugin_config
+from .deploy import dsd_deploy

--- a/dsd_platformsh/deploy.py
+++ b/dsd_platformsh/deploy.py
@@ -1,21 +1,21 @@
 """Manages all platform.sh-specific aspects of the deployment process."""
 
 
-import simple_deploy
+import django_simple_deploy
 
 from dsd_platformsh.platform_deployer import PlatformDeployer
 from .plugin_config import PluginConfig
 
 
-@simple_deploy.hookimpl
-def simple_deploy_get_plugin_config():
+@django_simple_deploy.hookimpl
+def dsd_get_plugin_config():
     """Get platform-specific attributes needed by core."""
     plugin_config = PluginConfig()
     return plugin_config
 
 
-@simple_deploy.hookimpl
-def simple_deploy_deploy():
+@django_simple_deploy.hookimpl
+def dsd_deploy():
     """Carry out platform-specific deployment steps."""
     platform_deployer = PlatformDeployer()
     platform_deployer.deploy()

--- a/dsd_platformsh/deploy_messages.py
+++ b/dsd_platformsh/deploy_messages.py
@@ -175,7 +175,7 @@ def success_msg(log_output=""):
     if log_output:
         msg += dedent(
             f"""
-        - You can find a full record of this configuration in the django_simple_deploy_logs directory.
+        - You can find a full record of this configuration in the dsd_logs directory.
         """
         )
 

--- a/dsd_platformsh/deploy_messages.py
+++ b/dsd_platformsh/deploy_messages.py
@@ -175,7 +175,7 @@ def success_msg(log_output=""):
     if log_output:
         msg += dedent(
             f"""
-        - You can find a full record of this configuration in the simple_deploy_logs directory.
+        - You can find a full record of this configuration in the django_simple_deploy_logs directory.
         """
         )
 

--- a/dsd_platformsh/deploy_messages.py
+++ b/dsd_platformsh/deploy_messages.py
@@ -8,7 +8,7 @@ from django.conf import settings
 
 
 confirm_automate_all = """
-The --automate-all flag means simple_deploy will:
+The --automate-all flag means the deploy command will:
 - Run `platform create` for you, to create an empty Platform.sh project.
   - This will create a project in the us-3.platform.sh region. If you wish
     to use a different region, cancel this operation and use the --region flag.
@@ -89,7 +89,7 @@ An unknown error has occurred. Do you have the Platform.sh CLI installed?
 may_configure = """
 You may want to re-run the deploy command without the --automate-all flag.
 
-You will have to create the Platform.sh project yourself, but simple_deploy
+You will have to create the Platform.sh project yourself, but django-simple-deploy
 will do all of the necessary configuration for deployment.
 """
 

--- a/dsd_platformsh/platform_deployer.py
+++ b/dsd_platformsh/platform_deployer.py
@@ -13,7 +13,7 @@ from django.utils.crypto import get_random_string
 from django.utils.safestring import mark_safe
 
 from django_simple_deploy.management.commands.utils import plugin_utils
-from django_simple_deploy.management.commands.utils.plugin_utils import sd_config
+from django_simple_deploy.management.commands.utils.plugin_utils import dsd_config
 from django_simple_deploy.management.commands.utils.command_errors import (
     DSDCommandError,
 )
@@ -69,10 +69,10 @@ class PlatformDeployer:
         Raises:
             DSDCommandError: If we find any reason deployment won't work.
         """
-        if sd_config.unit_testing:
+        if dsd_config.unit_testing:
             # Unit tests don't use the CLI. Use the deployed project name that was
             # passed to the simple_deploy CLI.
-            self.deployed_project_name = sd_config.deployed_project_name
+            self.deployed_project_name = dsd_config.deployed_project_name
             plugin_utils.log_info(
                 f"Deployed project name: {self.deployed_project_name}"
             )
@@ -99,14 +99,14 @@ class PlatformDeployer:
         Note: create command outputs project id to stdout if known, all other
           output goes to stderr.
         """
-        if not sd_config.automate_all:
+        if not dsd_config.automate_all:
             return
 
         plugin_utils.write_output("  Running `platform create`...")
         plugin_utils.write_output(
             "    (Please be patient, this can take a few minutes."
         )
-        cmd = f"platform create --title { self.deployed_project_name } --org {self.org_name} --region {sd_config.region} --yes"
+        cmd = f"platform create --title { self.deployed_project_name } --org {self.org_name} --region {dsd_config.region} --yes"
 
         try:
             # Note: if user can't create a project the returncode will be 6, not 1.
@@ -132,23 +132,23 @@ class PlatformDeployer:
         """Add a .platform.app.yaml file."""
 
         # Build contents from template.
-        if sd_config.pkg_manager == "poetry":
+        if dsd_config.pkg_manager == "poetry":
             template_path = "poetry.platform.app.yaml"
-        elif sd_config.pkg_manager == "pipenv":
+        elif dsd_config.pkg_manager == "pipenv":
             template_path = "pipenv.platform.app.yaml"
         else:
             template_path = "platform.app.yaml"
         template_path = self.templates_path / template_path
 
         context = {
-            "project_name": sd_config.local_project_name,
+            "project_name": dsd_config.local_project_name,
             "deployed_project_name": self.deployed_project_name,
         }
 
         contents = plugin_utils.get_template_string(template_path, context)
 
         # Write file to project.
-        path = sd_config.project_root / ".platform.app.yaml"
+        path = dsd_config.project_root / ".platform.app.yaml"
         plugin_utils.add_file(path, contents)
 
     def _add_requirements(self):
@@ -158,7 +158,7 @@ class PlatformDeployer:
 
     def _add_platform_dir(self):
         """Add a .platform directory, if it doesn't already exist."""
-        self.platform_dir_path = sd_config.project_root / ".platform"
+        self.platform_dir_path = dsd_config.project_root / ".platform"
         plugin_utils.add_dir(self.platform_dir_path)
 
     def _add_services_yaml(self):
@@ -178,7 +178,7 @@ class PlatformDeployer:
         - Open project.
         """
         # Making this check here lets deploy() be cleaner.
-        if not sd_config.automate_all:
+        if not dsd_config.automate_all:
             return
 
         plugin_utils.commit_changes()
@@ -221,11 +221,11 @@ class PlatformDeployer:
         # - Describe ongoing approach of commit, push, migrate. Lots to consider
         #   when doing this on production app with users, make sure you learn.
 
-        if sd_config.automate_all:
+        if dsd_config.automate_all:
             msg = platform_msgs.success_msg_automate_all(self.deployed_url)
             plugin_utils.write_output(msg)
         else:
-            msg = platform_msgs.success_msg(sd_config.log_output)
+            msg = platform_msgs.success_msg(dsd_config.log_output)
             plugin_utils.write_output(msg)
 
     # --- Helper methods for methods called from deploy.py ---
@@ -275,12 +275,12 @@ class PlatformDeployer:
             DSDCommandError: If deployed project name can't be found.
         """
         # If we're creating the project, we'll just use the startproject name.
-        if sd_config.automate_all:
-            return sd_config.local_project_name
+        if dsd_config.automate_all:
+            return dsd_config.local_project_name
 
         # Use the provided name if --deployed-project-name specified.
-        if sd_config.deployed_project_name:
-            return sd_config.deployed_project_name
+        if dsd_config.deployed_project_name:
+            return dsd_config.deployed_project_name
 
         # Use --yes flag to avoid interactive prompt hanging in background
         #   if the user is not currently logged in to the CLI.
@@ -340,7 +340,7 @@ class PlatformDeployer:
             - if org name found, but not confirmed.
             - if org name not found
         """
-        if not sd_config.automate_all:
+        if not dsd_config.automate_all:
             return
 
         cmd = "platform organization:list --yes --format csv"
@@ -388,11 +388,11 @@ class PlatformDeployer:
             DSDCommandError: if not confirmed
         """
 
-        sd_config.stdout.write(platform_msgs.confirm_use_org(org_name))
+        dsd_config.stdout.write(platform_msgs.confirm_use_org(org_name))
         confirmed = plugin_utils.get_confirmation(skip_logging=True)
 
         if confirmed:
-            sd_config.stdout.write("  Okay, continuing with deployment.")
+            dsd_config.stdout.write("  Okay, continuing with deployment.")
             return True
         else:
             # Exit, with a message that configuration is still an option.

--- a/dsd_platformsh/platform_deployer.py
+++ b/dsd_platformsh/platform_deployer.py
@@ -12,9 +12,9 @@ from django.core.management.utils import get_random_secret_key
 from django.utils.crypto import get_random_string
 from django.utils.safestring import mark_safe
 
-from simple_deploy.management.commands.utils import plugin_utils
-from simple_deploy.management.commands.utils.plugin_utils import sd_config
-from simple_deploy.management.commands.utils.command_errors import (
+from django_simple_deploy.management.commands.utils import plugin_utils
+from django_simple_deploy.management.commands.utils.plugin_utils import sd_config
+from django_simple_deploy.management.commands.utils.command_errors import (
     SimpleDeployCommandError,
 )
 
@@ -228,7 +228,7 @@ class PlatformDeployer:
             msg = platform_msgs.success_msg(sd_config.log_output)
             plugin_utils.write_output(msg)
 
-    # --- Helper methods for methods called from simple_deploy.py ---
+    # --- Helper methods for methods called from deploy.py ---
 
     def _check_plsh_settings(self):
         """Check to see if a Platform.sh settings block already exists."""

--- a/dsd_platformsh/plugin_config.py
+++ b/dsd_platformsh/plugin_config.py
@@ -6,7 +6,7 @@ from . import deploy_messages as platform_msgs
 class PluginConfig:
     """Class for managing attributes that need to be shared with core.
 
-    This is similar to the class SDConfig in core's sd_config.py.
+    This is similar to the class DSDConfig in core's dsd_config.py.
 
     This should future-proof plugins somewhat, in that if more information needs
     to be shared back to core, it can be added here without breaking changes to the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dsd-platformsh"
-version = "0.9.1"
+version = "0.9.3"
 description = "A plugin for django-simple-deploy, supporting deployments to Platform.sh."
 readme = "README.md"
 

--- a/tests/integration_tests/reference_files/.gitignore
+++ b/tests/integration_tests/reference_files/.gitignore
@@ -7,4 +7,4 @@ __pycache__/
 
 db.sqlite3
 
-django_simple_deploy_logs/
+dsd_logs/

--- a/tests/integration_tests/reference_files/.gitignore
+++ b/tests/integration_tests/reference_files/.gitignore
@@ -7,4 +7,4 @@ __pycache__/
 
 db.sqlite3
 
-simple_deploy_logs/
+django_simple_deploy_logs/

--- a/tests/integration_tests/reference_files/settings.py
+++ b/tests/integration_tests/reference_files/settings.py
@@ -35,7 +35,7 @@ INSTALLED_APPS = [
     "blogs",
     "users",
     # Third party apps.
-    "simple_deploy",
+    "django_simple_deploy",
     "django_bootstrap5",
     # Default django apps.
     "django.contrib.admin",

--- a/tests/integration_tests/test_platformsh_config.py
+++ b/tests/integration_tests/test_platformsh_config.py
@@ -86,7 +86,7 @@ def test_services_yaml_file(tmp_project):
 
 def test_log_dir(tmp_project):
     """Test that the log directory exists, and contains an appropriate log file."""
-    log_path = Path(tmp_project / "simple_deploy_logs")
+    log_path = Path(tmp_project / "django_simple_deploy_logs")
     assert log_path.exists()
 
     # DEV: After implementing friendly summary for Platform.sh, this file
@@ -119,7 +119,7 @@ def test_log_dir(tmp_project):
     assert "INFO:   Using plugin: dsd_platformsh" in log_file_text
     assert "INFO: Local project name: blog" in log_file_text
     assert "INFO: git status --porcelain" in log_file_text
-    assert "INFO: ?? simple_deploy_logs/" in log_file_text
+    assert "INFO: ?? django_simple_deploy_logs/" in log_file_text
 
     # Spot check for success messages.
     assert (
@@ -129,6 +129,6 @@ def test_log_dir(tmp_project):
     assert "INFO: To deploy your project, you will need to:" in log_file_text
 
     assert (
-        "INFO: - You can find a full record of this configuration in the simple_deploy_logs directory."
+        "INFO: - You can find a full record of this configuration in the django_simple_deploy_logs directory."
         in log_file_text
     )

--- a/tests/integration_tests/test_platformsh_config.py
+++ b/tests/integration_tests/test_platformsh_config.py
@@ -86,7 +86,7 @@ def test_services_yaml_file(tmp_project):
 
 def test_log_dir(tmp_project):
     """Test that the log directory exists, and contains an appropriate log file."""
-    log_path = Path(tmp_project / "django_simple_deploy_logs")
+    log_path = Path(tmp_project / "dsd_logs")
     assert log_path.exists()
 
     # DEV: After implementing friendly summary for Platform.sh, this file
@@ -119,7 +119,7 @@ def test_log_dir(tmp_project):
     assert "INFO:   Using plugin: dsd_platformsh" in log_file_text
     assert "INFO: Local project name: blog" in log_file_text
     assert "INFO: git status --porcelain" in log_file_text
-    assert "INFO: ?? django_simple_deploy_logs/" in log_file_text
+    assert "INFO: ?? dsd_logs/" in log_file_text
 
     # Spot check for success messages.
     assert (
@@ -129,6 +129,6 @@ def test_log_dir(tmp_project):
     assert "INFO: To deploy your project, you will need to:" in log_file_text
 
     assert (
-        "INFO: - You can find a full record of this configuration in the django_simple_deploy_logs directory."
+        "INFO: - You can find a full record of this configuration in the dsd_logs directory."
         in log_file_text
     )

--- a/tests/integration_tests/test_platformsh_config.py
+++ b/tests/integration_tests/test_platformsh_config.py
@@ -8,7 +8,7 @@ import pytest
 from tests.integration_tests.utils import it_helper_functions as hf
 from tests.integration_tests.conftest import (
     tmp_project,
-    run_simple_deploy,
+    run_dsd,
     reset_test_project,
     pkg_manager,
 )


### PR DESCRIPTION
Includes a number of less significant name changes for consistency.