### PR TITLE
Support wagtail

### DIFF
--- a/dsd_platformsh/platform_deployer.py
+++ b/dsd_platformsh/platform_deployer.py
@@ -49,6 +49,7 @@ class PlatformDeployer:
         self._add_platform_app_yaml()
         self._add_platform_dir()
         self._add_services_yaml()
+        self._settings_env_var()
 
         self._conclude_automate_all()
         self._show_success_message()
@@ -169,6 +170,15 @@ class PlatformDeployer:
 
         path = self.platform_dir_path / "services.yaml"
         plugin_utils.add_file(path, contents)
+
+    def _settings_env_var(self):
+        """Set the settings env var, if needed."""
+        # This is primarily for Wagtail projects.
+        if dsd_config.settings_path.parts[-2:] == ("settings", "production.py"):
+            dotted_settings_path = ".".join(dsd_config.settings_path.parts[-3:])
+            cmd = f"platform variable:create --level environment --name DJANGO_SETTINGS_MODULE {dotted_settings_path}"
+            output = plugin_utils.run_quick_command(cmd)
+            plugin_utils.write_output(output)
 
     def _conclude_automate_all(self):
         """Finish automating the push to Platform.sh.

--- a/dsd_platformsh/platform_deployer.py
+++ b/dsd_platformsh/platform_deployer.py
@@ -175,6 +175,7 @@ class PlatformDeployer:
         """Set the settings env var, if needed."""
         # This is primarily for Wagtail projects.
         if dsd_config.settings_path.parts[-2:] == ("settings", "production.py"):
+            plugin_utils.write_output("  Setting DJANGO_SETTINGS_MODULE environment variable...")
             dotted_settings_path = ".".join(dsd_config.settings_path.parts[-3:])
             cmd = f"platform variable:create --level environment --name DJANGO_SETTINGS_MODULE --value {dotted_settings_path}"
             output = plugin_utils.run_quick_command(cmd)

--- a/dsd_platformsh/platform_deployer.py
+++ b/dsd_platformsh/platform_deployer.py
@@ -176,8 +176,9 @@ class PlatformDeployer:
         # This is primarily for Wagtail projects.
         if dsd_config.settings_path.parts[-2:] == ("settings", "production.py"):
             plugin_utils.write_output("  Setting DJANGO_SETTINGS_MODULE environment variable...")
-            dotted_settings_path = ".".join(dsd_config.settings_path.parts[-3:])
-            cmd = f"platform variable:create --level environment --name DJANGO_SETTINGS_MODULE --value {dotted_settings_path}"
+            dotted_settings_path = ".".join(dsd_config.settings_path.parts[-3:]).removesuffix(".py")
+            breakpoint()
+            cmd = f"platform variable:create --level environment --name DJANGO_SETTINGS_MODULE --value {dotted_settings_path} --no-interaction"
             output = plugin_utils.run_quick_command(cmd)
             plugin_utils.write_output(output)
 

--- a/dsd_platformsh/platform_deployer.py
+++ b/dsd_platformsh/platform_deployer.py
@@ -177,7 +177,6 @@ class PlatformDeployer:
         if dsd_config.settings_path.parts[-2:] == ("settings", "production.py"):
             plugin_utils.write_output("  Setting DJANGO_SETTINGS_MODULE environment variable...")
             dotted_settings_path = ".".join(dsd_config.settings_path.parts[-3:]).removesuffix(".py")
-            breakpoint()
             cmd = f"platform variable:create --level environment --name DJANGO_SETTINGS_MODULE --value {dotted_settings_path} --no-interaction"
             output = plugin_utils.run_quick_command(cmd)
             plugin_utils.write_output(output)

--- a/dsd_platformsh/platform_deployer.py
+++ b/dsd_platformsh/platform_deployer.py
@@ -172,12 +172,14 @@ class PlatformDeployer:
         plugin_utils.add_file(path, contents)
 
     def _settings_env_var(self):
-        """Set the settings env var, if needed."""
-        # This is primarily for Wagtail projects.
+        """Set the DJANGO_SETTINGS_MODULE env var, if needed."""
+        # This is primarily for Wagtail projects, as signified by a settings/production.py file.
         if dsd_config.settings_path.parts[-2:] == ("settings", "production.py"):
             plugin_utils.write_output("  Setting DJANGO_SETTINGS_MODULE environment variable...")
+
+            # Need form mysite.settings.production
             dotted_settings_path = ".".join(dsd_config.settings_path.parts[-3:]).removesuffix(".py")
-            # cmd = f"platform variable:create --level environment --environment . --name DJANGO_SETTINGS_MODULE --value {dotted_settings_path} --no-interaction"
+
             cmd = f"platform variable:create --level environment --environment main --name DJANGO_SETTINGS_MODULE --value {dotted_settings_path} --no-interaction --visible-build true --prefix env"
             output = plugin_utils.run_quick_command(cmd)
             plugin_utils.write_output(output)

--- a/dsd_platformsh/platform_deployer.py
+++ b/dsd_platformsh/platform_deployer.py
@@ -176,7 +176,7 @@ class PlatformDeployer:
         # This is primarily for Wagtail projects.
         if dsd_config.settings_path.parts[-2:] == ("settings", "production.py"):
             dotted_settings_path = ".".join(dsd_config.settings_path.parts[-3:])
-            cmd = f"platform variable:create --level environment --name DJANGO_SETTINGS_MODULE {dotted_settings_path}"
+            cmd = f"platform variable:create --level environment --name DJANGO_SETTINGS_MODULE --value {dotted_settings_path}"
             output = plugin_utils.run_quick_command(cmd)
             plugin_utils.write_output(output)
 

--- a/dsd_platformsh/platform_deployer.py
+++ b/dsd_platformsh/platform_deployer.py
@@ -177,7 +177,8 @@ class PlatformDeployer:
         if dsd_config.settings_path.parts[-2:] == ("settings", "production.py"):
             plugin_utils.write_output("  Setting DJANGO_SETTINGS_MODULE environment variable...")
             dotted_settings_path = ".".join(dsd_config.settings_path.parts[-3:]).removesuffix(".py")
-            cmd = f"platform variable:create --level environment --environment . --name DJANGO_SETTINGS_MODULE --value {dotted_settings_path} --no-interaction"
+            # cmd = f"platform variable:create --level environment --environment . --name DJANGO_SETTINGS_MODULE --value {dotted_settings_path} --no-interaction"
+            cmd = f"platform variable:create --level environment --environment main --name DJANGO_SETTINGS_MODULE --value {dotted_settings_path} --no-interaction --visible-build true --prefix env"
             output = plugin_utils.run_quick_command(cmd)
             plugin_utils.write_output(output)
 

--- a/dsd_platformsh/platform_deployer.py
+++ b/dsd_platformsh/platform_deployer.py
@@ -177,7 +177,7 @@ class PlatformDeployer:
         if dsd_config.settings_path.parts[-2:] == ("settings", "production.py"):
             plugin_utils.write_output("  Setting DJANGO_SETTINGS_MODULE environment variable...")
             dotted_settings_path = ".".join(dsd_config.settings_path.parts[-3:]).removesuffix(".py")
-            cmd = f"platform variable:create --level environment --name DJANGO_SETTINGS_MODULE --value {dotted_settings_path} --no-interaction"
+            cmd = f"platform variable:create --level environment --environment . --name DJANGO_SETTINGS_MODULE --value {dotted_settings_path} --no-interaction"
             output = plugin_utils.run_quick_command(cmd)
             plugin_utils.write_output(output)
 

--- a/dsd_platformsh/templates/settings.py
+++ b/dsd_platformsh/templates/settings.py
@@ -9,7 +9,11 @@ if os.environ.get("PLATFORM_APPLICATION_NAME"):
 
     config = Config()
 
-    ALLOWED_HOSTS.append("*")
+    try:
+        ALLOWED_HOSTS.append("*")
+    except NameError:
+        ALLOWED_HOSTS = ["*"]
+        
     DEBUG = False
 
     STATIC_URL = "/static/"

--- a/tests/integration_tests/reference_files/settings.py
+++ b/tests/integration_tests/reference_files/settings.py
@@ -142,7 +142,11 @@ if os.environ.get("PLATFORM_APPLICATION_NAME"):
 
     config = Config()
 
-    ALLOWED_HOSTS.append("*")
+    try:
+        ALLOWED_HOSTS.append("*")
+    except NameError:
+        ALLOWED_HOSTS = ["*"]
+        
     DEBUG = False
 
     STATIC_URL = "/static/"


### PR DESCRIPTION
Adds support for deploying Wagtail projects to Platform.sh. Accommodates no existing `ALLOWED_HOSTS` setting, and sets `DJANGO_SETTINGS_MODULE` env var to `project_name.settings.production`.